### PR TITLE
Handle case where viewportHeigh is equal to heighOffset

### DIFF
--- a/src/Codeception/Module/VisualCeption.php
+++ b/src/Codeception/Module/VisualCeption.php
@@ -521,12 +521,14 @@ class VisualCeption extends CodeceptionModule implements MultiSession
                 }
             }
 
-            $screenshotBinary = $this->webDriver->takeScreenshot();
-            $screenShotImage->readimageblob($screenshotBinary);
-            $heightOffset = $viewportHeight - ($height - (intval($itr) * $viewportHeight));
+            if (!is_int($itr) || $height <= $viewportHeight) {
+                $screenshotBinary = $this->webDriver->takeScreenshot();
+                $screenShotImage->readimageblob($screenshotBinary);
+                $heightOffset = $viewportHeight - ($height - (intval($itr) * $viewportHeight));
 
-            if ($isViewPortHeightBiggerThanPageHeight) {
-                $screenShotImage->cropImage(0, 0, 0, $heightOffset * $devicePixelRatio);
+                if ($isViewPortHeightBiggerThanPageHeight) {
+                    $screenShotImage->cropImage(0, 0, 0, $heightOffset * $devicePixelRatio);
+                }
             }
 
             $screenShotImage->resetIterator();


### PR DESCRIPTION
This pull request addresses an issue with the full-screen screenshot functionality when the page size exceeds the device's viewport. The problem occurs during the final screenshot, which requires cropping. A specific edge case was not handled: when the last screenshot matches the exact pixel dimensions of the device’s viewport, it results in throwing an error `geometry does not contain image @ warning/transform.c/CropImage/718`

